### PR TITLE
Shared access token

### DIFF
--- a/ServiceBusJS/Scripts/servicebusjssdk-1.2.js
+++ b/ServiceBusJS/Scripts/servicebusjssdk-1.2.js
@@ -215,8 +215,12 @@ function QueueClient(config) {
         return uri;
     }
 
+    var getToken = function () {
+        return generateToken(m_EntityName);
+    };
+
     // Creates shared access signature token.
-    var getToken = function (entityPath) {
+    var generateToken = function (entityPath) {
 
         var uri = "http://" + m_ServiceNamespace + ".servicebus.windows.net/" + entityPath;
 
@@ -285,7 +289,7 @@ function QueueClient(config) {
         var body = JSON.stringify(message.body);
         var props = message.properties;
 
-        var securityToken = getToken(m_EntityName);
+        var securityToken = getToken();
         var sendUri = getUri(m_EntityName);
         var xmlHttpRequest = new XMLHttpRequest();
 
@@ -338,7 +342,7 @@ function QueueClient(config) {
         /// <param name="callback" type="function">
         /// function to be invoked after the message has received or receiving process has failed.
         /// </param>
-        var securityToken = getToken(m_EntityName);
+        var securityToken = getToken();
 
         var xmlHttpRequest = new XMLHttpRequest();
         var receiveUri = getUri(m_EntityName, "head");
@@ -384,7 +388,7 @@ function QueueClient(config) {
         /// <param name="callback" type="function">
         /// function to be invoked after the message has received or receiving process has failed.
         /// </param>      
-        var securityToken = getToken(m_EntityName);
+        var securityToken = getToken();
         var uri = getUri(m_EntityName, "head");
 
         var xmlHttpRequest = new XMLHttpRequest();
@@ -433,7 +437,7 @@ function QueueClient(config) {
         /// The URI which has been previouslly retrieved by peekLockMessage() function.
         /// </param>
         var xmlHttpRequest = new XMLHttpRequest();
-        var securityToken = getToken(m_EntityName);
+        var securityToken = getToken();
 
         xmlHttpRequest.open("PUT", lockUri, true);
         xmlHttpRequest.setRequestHeader("Authorization", securityToken);
@@ -469,7 +473,7 @@ function QueueClient(config) {
         /// <param name="lockUri" type="function">
         /// The URI which has been previouslly retrieved by peekLockMessage() function.
         /// </param>
-        var securityToken = getToken(m_EntityName);
+        var securityToken = getToken();
         var xmlHttpRequest = new XMLHttpRequest();
         xmlHttpRequest.open("DELETE", lockUri, true);
         xmlHttpRequest.setRequestHeader("Authorization", securityToken);

--- a/ServiceBusJS/Scripts/servicebusjssdk-1.2.js
+++ b/ServiceBusJS/Scripts/servicebusjssdk-1.2.js
@@ -171,6 +171,7 @@ function QueueClient(config) {
     /// 'namespace': "your service bus namespace",
     /// 'sasKey': "**cBg=",
     /// 'sasKeyName': the name of the key for SAS "device_send_listen",
+    /// 'sasToken': shared access token string,
     /// 'timeOut': Defines the timeout in seconds in communication with service bus endpoint.,
     /// </param>
     var m_EntityName = "Please provide the queue name. For example 'customer/orders'";
@@ -183,6 +184,8 @@ function QueueClient(config) {
 
     var m_SasKeyName = "provide the SAS key name.";
 
+    var m_SasToken = null;
+
     m_ServiceNamespace = config.namespace;
 
     if (config.name != null)
@@ -193,7 +196,8 @@ function QueueClient(config) {
         m_SasKeyName = config.sasKeyName;
     if (config.timeOut != null)
         m_Timeout = config.timeOut;
-
+    if (config.sasToken != null)
+        m_SasToken = config.sasToken;
     if (config.contentType == null)
         m_ContentType = "application/json";
 

--- a/ServiceBusJS/Scripts/servicebusjssdk-1.2.js
+++ b/ServiceBusJS/Scripts/servicebusjssdk-1.2.js
@@ -220,7 +220,11 @@ function QueueClient(config) {
     }
 
     var getToken = function () {
-        return generateToken(m_EntityName);
+        if (m_SasToken === null) {
+            return generateToken(m_EntityName);
+        } else {
+            return m_SasToken;
+        }
     };
 
     // Creates shared access signature token.


### PR DESCRIPTION
Main reason why Shared Access Token have been introduced into Azure world was to give opportunity of managing authentication and authorization to different services or their fragments[1] without the necessity of disclosing secret keys to them[2]. Therefore while I can imagine situation where possibility of generating SAS tokens on client side can be useful, it should not be default let alone **only** way ASB SDK authenticates to the queues. In my opinion it can even be considered violation of security and SAS technology best practices in most cases.

Presented pull request adds possibility of explicit supplying of SAS token instead of generating it based on known secret. Thanks to that, web application can avoid disclosing secrets and rely responsibility of access control on some other server- side logic[2].

[1] http://blogs.msdn.com/b/windowsazurestorage/archive/2012/06/12/introducing-table-sas-shared-access-signature-queue-sas-and-update-to-blob-sas.aspx
[2] http://blogs.msdn.com/b/windowsazurestorage/archive/2012/06/12/introducing-table-sas-shared-access-signature-queue-sas-and-update-to-blob-sas.aspx
